### PR TITLE
add docker into runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,22 @@ RUN apt-get update \
         git \
         jq \
         iputils-ping \
+        apt-transport-https \
+        ca-certificates \
+        gnupg-agent \
+        software-properties-common \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - \
+    && sudo add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/debian \
+       $(lsb_release -cs) \
+       stable" \
+    && apt-get update \
+    && apt-get install -y docker-ce docker-ce-cli containerd.io \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m github \
     && usermod -aG sudo github \
+    && usermod -aG docker github \
     && echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 USER github


### PR DESCRIPTION
add docker executable to the sanderknape github runner docker image in order to be able to build docker images and run docker based github actions